### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   pre-commit:
+    permissions:
+      contents: read
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/reflex-dev/reflex-okta-auth/security/code-scanning/1](https://github.com/reflex-dev/reflex-okta-auth/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block to the workflow or to the specific job so that the `GITHUB_TOKEN` is limited to the minimal scope needed. For this pre-commit job, the minimal required permission is to read repository contents; no write permissions or other scopes (issues, pull-requests, etc.) are needed.

The best fix with minimal behavioral impact is to add a job-level `permissions` block under the `pre-commit` job, specifying `contents: read`. This ensures the job’s token cannot write to the repository even if the repo/org default is read-write. Concretely, in `.github/workflows/pre-commit.yml`, add:

```yaml
permissions:
  contents: read
```

indented under the `pre-commit` job (line 10), between `pre-commit:` and `timeout-minutes: 30` (line 11). No new imports or external packages are required; this is purely a configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
